### PR TITLE
Specialized set_dot for one-entry vector

### DIFF
--- a/src/dual_equality_constraints.jl
+++ b/src/dual_equality_constraints.jl
@@ -409,6 +409,9 @@ struct OneEntryVector{T} <: AbstractVector{T}
     value::T
     index::Int
     n::Int
+    function OneEntryVector{T}(value::T, index::Integer, n::Integer)
+        return new{T}(value, index, n)
+    end
 end
 Base.eltype(::Type{OneEntryVector{T}}) where {T} = T
 Base.length(v::OneEntryVector) = v.n

--- a/src/dual_equality_constraints.jl
+++ b/src/dual_equality_constraints.jl
@@ -409,9 +409,6 @@ struct OneEntryVector{T} <: AbstractVector{T}
     value::T
     index::Int
     n::Int
-    function OneEntryVector{T}(value::T, index::Integer, n::Integer)
-        return new{T}(value, index, n)
-    end
 end
 Base.eltype(::Type{OneEntryVector{T}}) where {T} = T
 Base.length(v::OneEntryVector) = v.n
@@ -442,7 +439,7 @@ function MOI.Utilities.triangle_dot(
 end
 
 function set_dot(i::Integer, s::MOI.AbstractVectorSet, T::Type)
-    vec = OneEntryVector(one(T), i, MOI.dimension(s))
+    vec = OneEntryVector{T}(one(T), i, MOI.dimension(s))
     return MOIU.set_dot(vec, vec, s)
 end
 function set_dot(::Integer, ::MOI.AbstractScalarSet, T::Type)

--- a/src/dual_equality_constraints.jl
+++ b/src/dual_equality_constraints.jl
@@ -410,6 +410,9 @@ struct OneEntryVector{T} <: AbstractVector{T}
     index::Int
     n::Int
 end
+Base.eltype(::Type{OneEntryVector{T}}) where {T} = T
+Base.length(v::OneEntryVector) = v.n
+Base.size(v::OneEntryVector) = (v.n,)
 function Base.getindex(v::OneEntryVector{T}, i::Integer) where {T}
     if i == v.index
         return v.value


### PR DESCRIPTION
On the benchmark of https://github.com/jump-dev/MathOptInterface.jl/issues/1796, in terms of allocations:
|                | theta1    | thetaG11   |
|----------------|-----------|------------|
| Before this PR | 14.693 MB | 793.687 GB |
| After this PR  | 0.395 MB | 0.039 GB   |

and in terms of time:

|                | theta1    | thetaG11   |
|----------------|-----------|------------|
| Before this PR | 28.5 ms | 232 s |
| After this PR  | 0.586 ms | 0.108 s   |

So for thetaG11, this gives a 20000x speedup in allocation and 2000x speedup in time.

Closes https://github.com/jump-dev/Dualization.jl/issues/66