### PR TITLE
Avoid setting empty names to JuMP's object dictionary

### DIFF
--- a/test/Tests/test_JuMP_dualize.jl
+++ b/test/Tests/test_JuMP_dualize.jl
@@ -28,6 +28,7 @@ end
             @test backend(dual_JuMP_model).state == MOIU.EMPTY_OPTIMIZER
             @test MOI.get(backend(dual_JuMP_model), MOI.SolverName()) ==
                   MOI.get(primal_linear_optimizer[i], MOI.SolverName())
+
         end
     end
     @testset "set_dot on different sets" begin
@@ -51,8 +52,13 @@ end
         @constraint(model, eqcon, x == 1)
         @objective(model, Min, y + z)
 
+        # Test that unnamed objects don't create a key `Symbol("")` in `dual_model`.
+        @variable(model)
+        @constraint(model, x == y)
+
         dual_model = dualize(model; dual_names = DualNames("dual", ""))
 
         @test typeof(dual_model[:dualeqcon_1]) == VariableRef
+        @test !haskey(dual_model, Symbol(""))
     end
 end

--- a/test/Tests/test_JuMP_dualize.jl
+++ b/test/Tests/test_JuMP_dualize.jl
@@ -28,7 +28,6 @@ end
             @test backend(dual_JuMP_model).state == MOIU.EMPTY_OPTIMIZER
             @test MOI.get(backend(dual_JuMP_model), MOI.SolverName()) ==
                   MOI.get(primal_linear_optimizer[i], MOI.SolverName())
-
         end
     end
     @testset "set_dot on different sets" begin


### PR DESCRIPTION
On the benchmark of https://github.com/jump-dev/MathOptInterface.jl/issues/1796, in terms of allocations:
|                | theta1    | thetaG11   |
|----------------|-----------|------------|
| v0.5.2 | 14.693 MB | 793.687 GB |
| https://github.com/jump-dev/Dualization.jl/pull/135  | 0.395 MB | 0.039 GB   |
| https://github.com/jump-dev/Dualization.jl/pull/136  | 0.349 MB | 0.029 GB   |

and in terms of time:

|                | theta1    | thetaG11   |
|----------------|-----------|------------|
| v0.5.2 | 28.5 ms | 232 s |
| https://github.com/jump-dev/Dualization.jl/pull/135 | 0.586 ms | 0.108 s   |
| https://github.com/jump-dev/Dualization.jl/pull/136 | 0.397 ms | 0.068 s |