### PR TITLE
Speed up get_scalar_term for large vector constraints

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -30,30 +30,28 @@ end
 
 # This is used to fill the dual objective dictionary
 function get_scalar_term(
-    model::MOI.ModelLike,
+    func::MOI.AbstractVectorFunction,
+    ::MOI.AbstractVectorSet,
     i::Int,
-    ci::CI{F,S},
-) where {F<:MOI.AbstractVectorFunction,S<:MOI.AbstractVectorSet}
-    return MOI.constant(get_function(model, ci))[i]
+)
+    return MOI.constant(func)[i]
 end
 
 # This is used to fill the dual objective dictionary
 function get_scalar_term(
-    model::MOI.ModelLike,
+    ::MOI.VariableIndex,
+    set::MOI.AbstractScalarSet,
     i::Int,
-    ci::CI{VI,S},
-) where {S<:MOI.AbstractScalarSet}
-    return -MOI.constant(get_set(model, ci))
+)
+    return -MOI.constant(set)
 end
 
 # This is used to fill the dual objective dictionary
 function get_scalar_term(
-    model::MOI.ModelLike,
+    func::MOI.AbstractScalarFunction,
+    set::MOI.AbstractScalarSet,
     i::Int,
-    ci::CI{F,S},
-) where {F<:MOI.AbstractScalarFunction,S<:MOI.AbstractScalarSet}
-
+)
     # In this case there i only one constant in the function and one in the set
-    return MOI.constant(get_function(model, ci))[1] -
-           MOI.constant(get_set(model, ci))
+    return MOI.constant(func) - MOI.constant(set)
 end

--- a/test/Tests/test_dual_model_variables.jl
+++ b/test/Tests/test_dual_model_variables.jl
@@ -4,11 +4,14 @@
         primal_model = soc1_test()
         dual_obj_affine_terms = Dict{VI,Float64}()
         ci = CI{VVF,MOI.SecondOrderCone}(2)
+        func = MOI.get(primal_model, MOI.ConstraintFunction(), ci)
+        set = MOI.get(primal_model, MOI.ConstraintSet(), ci)
         Dualization.push_to_dual_obj_aff_terms!(
             primal_model,
             dual_obj_affine_terms,
             VI(1),
-            ci,
+            func,
+            set,
             1,
         )
         @test isempty(dual_obj_affine_terms)

--- a/test/Tests/test_dual_model_variables.jl
+++ b/test/Tests/test_dual_model_variables.jl
@@ -3,7 +3,10 @@
     @testset "push_to_dual_obj_aff_terms!" begin
         primal_model = soc1_test()
         dual_obj_affine_terms = Dict{VI,Float64}()
-        list = MOI.get(primal_model, MOI.ListOfConstraintIndices{VVF,MOI.SecondOrderCone}())
+        list = MOI.get(
+            primal_model,
+            MOI.ListOfConstraintIndices{VVF,MOI.SecondOrderCone}(),
+        )
         ci = first(list)
         func = MOI.get(primal_model, MOI.ConstraintFunction(), ci)
         set = MOI.get(primal_model, MOI.ConstraintSet(), ci)

--- a/test/Tests/test_dual_model_variables.jl
+++ b/test/Tests/test_dual_model_variables.jl
@@ -3,7 +3,8 @@
     @testset "push_to_dual_obj_aff_terms!" begin
         primal_model = soc1_test()
         dual_obj_affine_terms = Dict{VI,Float64}()
-        ci = CI{VVF,MOI.SecondOrderCone}(2)
+        list = MOI.get(primal_model, MOI.ListOfConstraintIndices{VVF,MOI.SecondOrderCone}())
+        ci = first(list)
         func = MOI.get(primal_model, MOI.ConstraintFunction(), ci)
         set = MOI.get(primal_model, MOI.ConstraintSet(), ci)
         Dualization.push_to_dual_obj_aff_terms!(


### PR DESCRIPTION
Getting the set and function repeatedly for each index of the same constraint is slower than getting it once for each constraint.

On the benchmark of https://github.com/jump-dev/MathOptInterface.jl/issues/1796, in terms of allocations:

|                | theta1    | thetaG11   |
|----------------|-----------|------------|
| v0.5.2 | 14.693 MB | 793.687 GB |
| https://github.com/jump-dev/Dualization.jl/pull/135  | 0.395 MB | 0.039 GB   |
| https://github.com/jump-dev/Dualization.jl/pull/136  | 0.349 MB | 0.029 GB   |
| https://github.com/jump-dev/Dualization.jl/pull/137  | 0.349 MB | 0.029 GB   |

and in terms of time:

|                | theta1    | thetaG11   |
|----------------|-----------|------------|
| v0.5.2 | 28.5 ms | 232 s |
| https://github.com/jump-dev/Dualization.jl/pull/135 | 0.586 ms | 0.108 s   |
| https://github.com/jump-dev/Dualization.jl/pull/136 | 0.397 ms | 0.068 s |
| https://github.com/jump-dev/Dualization.jl/pull/137 | 0.246 ms | 0.029 s |