### PR TITLE
Unique names don't require underscores

### DIFF
--- a/src/dual_model_variables.jl
+++ b/src/dual_model_variables.jl
@@ -148,8 +148,8 @@ function add_dual_variable(
     # Add each vi to the dictionary
     func = get_function(primal_model, ci)
     set = get_set(primal_model, ci)
+    unique_var = length(vis) == 1
     for (i, vi) in enumerate(vis)
-        unique_var = length(vis) == 1
         push_to_dual_obj_aff_terms!(
             primal_model,
             dual_obj_affine_terms,
@@ -178,7 +178,7 @@ function set_dual_variable_name(
     i::Int,
     ci_name::String,
     prefix::String,
-    unique_var::Bool = false,
+    unique_var::Bool,
 )
     isempty(ci_name) && return
     name = prefix * ci_name

--- a/src/dual_model_variables.jl
+++ b/src/dual_model_variables.jl
@@ -149,6 +149,7 @@ function add_dual_variable(
     func = get_function(primal_model, ci)
     set = get_set(primal_model, ci)
     for (i, vi) in enumerate(vis)
+        unique_var = length(vis) == 1
         push_to_dual_obj_aff_terms!(
             primal_model,
             dual_obj_affine_terms,
@@ -164,6 +165,7 @@ function add_dual_variable(
                 i,
                 ci_name,
                 dual_names.dual_variable_name_prefix,
+                unique_var,
             )
         end
     end
@@ -176,9 +178,14 @@ function set_dual_variable_name(
     i::Int,
     ci_name::String,
     prefix::String,
+    unique_var::Bool=false,
 )
     isempty(ci_name) && return
-    MOI.set(dual_model, MOI.VariableName(), vi, prefix * ci_name * "_$i")
+    name = prefix * ci_name
+    if !unique_var
+        name *= "_$i"
+    end
+    MOI.set(dual_model, MOI.VariableName(), vi, name)
     return
 end
 

--- a/src/dual_model_variables.jl
+++ b/src/dual_model_variables.jl
@@ -178,7 +178,7 @@ function set_dual_variable_name(
     i::Int,
     ci_name::String,
     prefix::String,
-    unique_var::Bool=false,
+    unique_var::Bool = false,
 )
     isempty(ci_name) && return
     name = prefix * ci_name

--- a/src/dual_model_variables.jl
+++ b/src/dual_model_variables.jl
@@ -148,7 +148,7 @@ function add_dual_variable(
     # Add each vi to the dictionary
     func = get_function(primal_model, ci)
     set = get_set(primal_model, ci)
-    unique_var = length(vis) == 1
+    is_unique_var = length(vis) == 1
     for (i, vi) in enumerate(vis)
         push_to_dual_obj_aff_terms!(
             primal_model,
@@ -165,7 +165,7 @@ function add_dual_variable(
                 i,
                 ci_name,
                 dual_names.dual_variable_name_prefix,
-                unique_var,
+                ensure_unique = !is_unique_var,
             )
         end
     end
@@ -177,12 +177,12 @@ function set_dual_variable_name(
     vi::MOI.VariableIndex,
     i::Int,
     ci_name::String,
-    prefix::String,
-    unique_var::Bool,
+    prefix::String;
+    ensure_unique::Bool = true,
 )
     isempty(ci_name) && return
     name = prefix * ci_name
-    if !unique_var
+    if ensure_unique
         name *= "_$i"
     end
     MOI.set(dual_model, MOI.VariableName(), vi, name)

--- a/test/Tests/test_JuMP_dualize.jl
+++ b/test/Tests/test_JuMP_dualize.jl
@@ -64,7 +64,7 @@ end
 
         dual_model = dualize(model; dual_names = DualNames("dual", ""))
 
-        @test typeof(dual_model[:dualeqcon_1]) == VariableRef
+        @test typeof(dual_model[:dualeqcon]) == VariableRef
         @test !haskey(dual_model, Symbol(""))
     end
     @testset "JuMP_dualize_kwargs" begin

--- a/test/Tests/test_dual_model_variables.jl
+++ b/test/Tests/test_dual_model_variables.jl
@@ -32,13 +32,13 @@
     @testset "set_dual_variable_name" begin
         primal_model = soc1_test()
         vi = MOI.VariableIndex(1)
-        Dualization.set_dual_variable_name(primal_model, vi, 1, "con", "")
+        Dualization.set_dual_variable_name(primal_model, vi, 1, "con", "", false)
         @test MOI.get(primal_model, MOI.VariableName(), vi) == "con_1"
         Dualization.set_dual_variable_name(primal_model, vi, 1, "con", "", true)
         @test MOI.get(primal_model, MOI.VariableName(), vi) == "con"
-        Dualization.set_dual_variable_name(primal_model, vi, 2, "con", "")
+        Dualization.set_dual_variable_name(primal_model, vi, 2, "con", "", false)
         @test MOI.get(primal_model, MOI.VariableName(), vi) == "con_2"
-        Dualization.set_dual_variable_name(primal_model, vi, 2, "con", "oi")
+        Dualization.set_dual_variable_name(primal_model, vi, 2, "con", "oi", false)
         @test MOI.get(primal_model, MOI.VariableName(), vi) == "oicon_2"
     end
 end

--- a/test/Tests/test_dual_model_variables.jl
+++ b/test/Tests/test_dual_model_variables.jl
@@ -32,13 +32,34 @@
     @testset "set_dual_variable_name" begin
         primal_model = soc1_test()
         vi = MOI.VariableIndex(1)
-        Dualization.set_dual_variable_name(primal_model, vi, 1, "con", "", false)
+        Dualization.set_dual_variable_name(
+            primal_model,
+            vi,
+            1,
+            "con",
+            "",
+            false,
+        )
         @test MOI.get(primal_model, MOI.VariableName(), vi) == "con_1"
         Dualization.set_dual_variable_name(primal_model, vi, 1, "con", "", true)
         @test MOI.get(primal_model, MOI.VariableName(), vi) == "con"
-        Dualization.set_dual_variable_name(primal_model, vi, 2, "con", "", false)
+        Dualization.set_dual_variable_name(
+            primal_model,
+            vi,
+            2,
+            "con",
+            "",
+            false,
+        )
         @test MOI.get(primal_model, MOI.VariableName(), vi) == "con_2"
-        Dualization.set_dual_variable_name(primal_model, vi, 2, "con", "oi", false)
+        Dualization.set_dual_variable_name(
+            primal_model,
+            vi,
+            2,
+            "con",
+            "oi",
+            false,
+        )
         @test MOI.get(primal_model, MOI.VariableName(), vi) == "oicon_2"
     end
 end

--- a/test/Tests/test_dual_model_variables.jl
+++ b/test/Tests/test_dual_model_variables.jl
@@ -32,34 +32,20 @@
     @testset "set_dual_variable_name" begin
         primal_model = soc1_test()
         vi = MOI.VariableIndex(1)
+        Dualization.set_dual_variable_name(primal_model, vi, 1, "con", "")
+        @test MOI.get(primal_model, MOI.VariableName(), vi) == "con_1"
         Dualization.set_dual_variable_name(
             primal_model,
             vi,
             1,
             "con",
             "",
-            false,
+            ensure_unique = false,
         )
-        @test MOI.get(primal_model, MOI.VariableName(), vi) == "con_1"
-        Dualization.set_dual_variable_name(primal_model, vi, 1, "con", "", true)
         @test MOI.get(primal_model, MOI.VariableName(), vi) == "con"
-        Dualization.set_dual_variable_name(
-            primal_model,
-            vi,
-            2,
-            "con",
-            "",
-            false,
-        )
+        Dualization.set_dual_variable_name(primal_model, vi, 2, "con", "")
         @test MOI.get(primal_model, MOI.VariableName(), vi) == "con_2"
-        Dualization.set_dual_variable_name(
-            primal_model,
-            vi,
-            2,
-            "con",
-            "oi",
-            false,
-        )
+        Dualization.set_dual_variable_name(primal_model, vi, 2, "con", "oi")
         @test MOI.get(primal_model, MOI.VariableName(), vi) == "oicon_2"
     end
 end

--- a/test/Tests/test_dual_model_variables.jl
+++ b/test/Tests/test_dual_model_variables.jl
@@ -34,6 +34,8 @@
         vi = MOI.VariableIndex(1)
         Dualization.set_dual_variable_name(primal_model, vi, 1, "con", "")
         @test MOI.get(primal_model, MOI.VariableName(), vi) == "con_1"
+        Dualization.set_dual_variable_name(primal_model, vi, 1, "con", "", true)
+        @test MOI.get(primal_model, MOI.VariableName(), vi) == "con"
         Dualization.set_dual_variable_name(primal_model, vi, 2, "con", "")
         @test MOI.get(primal_model, MOI.VariableName(), vi) == "con_2"
         Dualization.set_dual_variable_name(primal_model, vi, 2, "con", "oi")

--- a/test/Tests/test_dual_names.jl
+++ b/test/Tests/test_dual_names.jl
@@ -71,7 +71,7 @@
     }(
         1,
     )][1]
-    @test MOI.get(dual_model, MOI.VariableName(), vi_2) == "dualvar_lessthan_1"
+    @test MOI.get(dual_model, MOI.VariableName(), vi_2) == "dualvar_lessthan"
     # Query constraint names
     ci_1 = primal_dual_map.primal_var_dual_con[MOI.VariableIndex(1)]
     ci_2 = primal_dual_map.primal_var_dual_con[MOI.VariableIndex(2)]

--- a/test/optimize_abstract_models.jl
+++ b/test/optimize_abstract_models.jl
@@ -7,10 +7,7 @@
 Attach an MOI.ModelLike to an optimizer,
 solve it and retrieve the termination status and objective value
 """
-function solve_abstract_model(
-    model::MOI.ModelLike,
-    optimizer_constructor,
-)
+function solve_abstract_model(model::MOI.ModelLike, optimizer_constructor)
     JuMP_model = JuMP.Model()
     MOI.copy_to(JuMP.backend(JuMP_model), model)
     set_optimizer(JuMP_model, optimizer_constructor)

--- a/test/optimize_abstract_models.jl
+++ b/test/optimize_abstract_models.jl
@@ -10,7 +10,7 @@ solve it and retrieve the termination status and objective value
 function solve_abstract_model(
     model::MOI.ModelLike,
     optimizer_constructor,
-) where {T}
+)
     JuMP_model = JuMP.Model()
     MOI.copy_to(JuMP.backend(JuMP_model), model)
     set_optimizer(JuMP_model, optimizer_constructor)


### PR DESCRIPTION
All models end up marking each variable group with `_$i`, even though the variables themselves are often in containers.

This typically ends up with a double indexing scheme in JuMP:
```
: π[6]_1 ≥ -8006.0
 : π[5]_1 ≥ -8005.0
```

This PR adapts it to avoid the `_i` if the variable name is unique