### PR TITLE
Fix param name

### DIFF
--- a/src/dual_model_variables.jl
+++ b/src/dual_model_variables.jl
@@ -142,7 +142,7 @@ function _add_primal_parameter_vars(
             prefix =
                 dual_names.parameter_name_prefix == "" ? "param_" :
                 dual_names.parameter_name_prefix
-            MOI.set(dual_model, MOI.VariableName(), vi, prefix * vi_name)
+            MOI.set(dual_model, MOI.VariableName(), vis[i], prefix * vi_name)
         end
     end
     return


### PR DESCRIPTION
```julia
julia> using JuMP, Dualization

julia> m = Model()
A JuMP Model
├ solver: none
├ objective_sense: FEASIBILITY_SENSE
├ num_variables: 0
├ num_constraints: 0
└ Names registered in the model: none

julia> @variable m x
x

julia> @variable m p ∈ Parameter(1.0)
@constrp

julia> @constraint m x ≥ p
x - p ≥ 0

julia> @objective m Min x
x

julia> dualize(m, dual_names=DualNames())
ERROR: UndefVarError: `vi` not defined in `Dualization`
```